### PR TITLE
Update to be compatible with 117

### DIFF
--- a/bin/games/petspa.ts
+++ b/bin/games/petspa.ts
@@ -13,7 +13,7 @@
  */
 
 import { decompressFromBase64 } from "lz-string";
-import { API_Connector, CoordObject, MessageEvent, makeDoorRegion, MapRegion, API_Character, AssetGet, BC_AppearanceItem, CommandParser, BC_Server_ChatRoomMessage } from "bc-bot";
+import { API_Connector, MessageEvent, makeDoorRegion, MapRegion, API_Character, AssetGet, BC_AppearanceItem, CommandParser, BC_Server_ChatRoomMessage } from "bc-bot";
 import { remainingTimeString } from "../utils";
 import { wait } from "../hub/utils";
 
@@ -24,16 +24,16 @@ const RECEPTION_AREA: MapRegion = {
 
 const RECEPTIONIST_POSITION = { X: 22, Y: 11 };
 
-const EXHIBIT_1: CoordObject = { X: 26, Y: 12 };
-const EXHIBIT_2: CoordObject = { X: 28, Y: 12 };
-const EXHIBIT_3: CoordObject = { X: 30, Y: 12 };
-const EXHIBIT_4: CoordObject = { X: 32, Y: 12 };
+const EXHIBIT_1: ChatRoomMapPos = { X: 26, Y: 12 };
+const EXHIBIT_2: ChatRoomMapPos = { X: 28, Y: 12 };
+const EXHIBIT_3: ChatRoomMapPos = { X: 30, Y: 12 };
+const EXHIBIT_4: ChatRoomMapPos = { X: 32, Y: 12 };
 
-const HALLWAY_TO_PET_AREA_DOOR: CoordObject = { X: 18, Y: 2 };
-const COMMON_AREA_TO_RECEPTION_DOOR: CoordObject = { X: 14, Y: 10 };
-const REDRESSING_PAD: CoordObject = { X: 18, Y: 8 };
+const HALLWAY_TO_PET_AREA_DOOR: ChatRoomMapPos = { X: 18, Y: 2 };
+const COMMON_AREA_TO_RECEPTION_DOOR: ChatRoomMapPos = { X: 14, Y: 10 };
+const REDRESSING_PAD: ChatRoomMapPos = { X: 18, Y: 8 };
 
-const DRESSING_PAD: CoordObject = { X: 23, Y: 5 };
+const DRESSING_PAD: ChatRoomMapPos = { X: 23, Y: 5 };
 
 const MAP =
     "N4IgKgngDgpiBcICCAbA7gQwgZxAGnAEsUZdEAgyq6m8wH+AAPJ5hugEw86+9t6sZZN23EZz586kyc2GiR4hfRlzRi8QNYr5a3gIDBsrRyknTZqcqNWjGw9fsc9bWw9dcXbroAXwHz/NnPb18vO25/EytgkJsAEL04hPjQkSjkrhiMzKy0oN8c4yzC/I5U2MLMu0An4Grq8hr6hsam+oB1tvaOzrbKroAz/q6unsGRluGO/t7R9vHpjtm2ybmx5c6FlqW59a29Xb39g8PKg+Xjw/Pzs73Ti9v9q92bu7uHvSfni9f3j6OTnZ/Ln8Wr4hgDAft2iC1mDfhC2lD5jCDl94T5QUi9ijpq8YVjRjiwXiRgSAUTBiSfmT0Ri9FToTTaUD8QzGXDsSzXvgQAB5ABGACsYABjAAuZBAgUlHEo2hlUu00vIRkANfDyrhytWarXayWAKvgdQbPIAxoCNhocgC4gS2Wg3ULSAavgRA6zdZAEPQbDdHsNACXnb63IABQD9QZUTuDYZ1gA/wDiAIAhwyIo1psHGzYBV8F9CeToljmaD2edgAYgDiALfAc8G0/GM37KwbC3Jq8766Wq2HGy2462DR2G5wu54uQAxAD2AHMEAAzDAobAwAC+QA";

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "bc-bot": "link:src",
-        "bc-stubs": "^116.0.0",
+        "bc-stubs": "117.0.0-Beta.1",
         "lodash": "^4.17.21",
         "lz-string": "^1.5.0",
         "mongodb": "^6.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: link:src
         version: link:src
       bc-stubs:
-        specifier: ^116.0.0
-        version: 116.0.0
+        specifier: 117.0.0-Beta.1
+        version: 117.0.0-Beta.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -360,8 +360,8 @@ packages:
   '@types/whatwg-url@11.0.5':
     resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
 
-  bc-stubs@116.0.0:
-    resolution: {integrity: sha512-70iudcyWi2MacZR0W8LCQegDkgBIjiEoyBe2NuTM2Nvj6/p6MT1M80byOSc1CpBeIdSurkJw8RUFqrTL/mXU6Q==}
+  bc-stubs@117.0.0-Beta.1:
+    resolution: {integrity: sha512-sX0fHJY0h6H1a89QAD2oY8uAa2apTkbXaC4xU0LGmUpKcVdlSMjz3V+SO8iH+N9HbM2ev3mhiO5YC2GjTV/cbw==}
 
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
@@ -684,7 +684,7 @@ snapshots:
     dependencies:
       '@types/webidl-conversions': 7.0.3
 
-  bc-stubs@116.0.0:
+  bc-stubs@117.0.0-Beta.1:
     dependencies:
       socket.io-client: 4.6.1
     transitivePeerDependencies:

--- a/src/apiCharacter.ts
+++ b/src/apiCharacter.ts
@@ -13,7 +13,7 @@
  */
 
 import { API_Chatroom } from "./apiChatroom";
-import { API_Connector, CoordObject, TellType } from "./apiConnector";
+import { API_Connector, TellType } from "./apiConnector";
 import { AppearanceType } from "./appearance";
 import { BC_AppearanceItem } from "./item";
 
@@ -60,7 +60,7 @@ export interface API_Character_Data {
     OnlineSharedSettings: OnlineSharedSettingsType;
     ItemPermission: ItemPermissionLevel;
     FriendList: number[];
-    MapData?: CoordObject;
+    MapData?: ChatRoomMapPos;
     BlockItems: ItemPermissionList;
     LimitedItems: ItemPermissionList;
 }
@@ -136,7 +136,7 @@ export class API_Character {
         return this.data.MapData?.Y ?? 0;
     }
 
-    public get MapPos(): CoordObject {
+    public get MapPos(): ChatRoomMapPos {
         return this.data.MapData ?? { X: 0, Y: 0 };
     }
 

--- a/src/apiChatroom.ts
+++ b/src/apiChatroom.ts
@@ -14,7 +14,7 @@
 
 import { EventEmitter } from "stream";
 import { API_Character, API_Character_Data } from "./apiCharacter";
-import { API_Connector, CoordObject, SingleItemUpdate } from "./apiConnector";
+import { API_Connector, SingleItemUpdate } from "./apiConnector";
 import { API_Map } from "./apiMap";
 import { API_AppearanceItem } from "./item";
 
@@ -236,7 +236,7 @@ export class API_Chatroom extends EventEmitter<ChatRoomEvents> {
         }
     }
 
-    public mapPositionUpdate(memberNumber: number, mapData: CoordObject) {
+    public mapPositionUpdate(memberNumber: number, mapData: ChatRoomMapPos) {
         const charData = this.data.Character.find(
             (x) => x.MemberNumber === memberNumber,
         );

--- a/src/apiConnector.ts
+++ b/src/apiConnector.ts
@@ -60,14 +60,9 @@ export interface SyncItemPayload {
     Item: SingleItemUpdate;
 }
 
-export interface CoordObject {
-    X: number;
-    Y: number;
-}
-
 export interface SyncMapDataPayload {
     MemberNumber: number;
-    MapData: CoordObject;
+    MapData: ChatRoomMapData;
 }
 
 // What the bot advertises as its game version
@@ -531,7 +526,7 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
 
     private onChatRoomSyncMapData = (update: SyncMapDataPayload) => {
         console.log("chat room map data", update);
-        this._chatRoom.mapPositionUpdate(update.MemberNumber, update.MapData);
+        this._chatRoom.mapPositionUpdate(update.MemberNumber, update.MapData.Pos);
     };
 
     private onChatRoomMessage = (msg: BC_Server_ChatRoomMessage) => {
@@ -817,8 +812,11 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
 
     public moveOnMap(x: number, y: number): void {
         this.wrappedSock.emit("ChatRoomCharacterMapDataUpdate", {
-            X: x,
-            Y: y,
+            Pos: {
+                X: x,
+                Y: y,
+            },
+            PrivateState: {},
         });
     }
 }

--- a/src/apiMap.ts
+++ b/src/apiMap.ts
@@ -15,13 +15,13 @@
 import { decompressFromBase64 } from "lz-string";
 import { API_Character } from "./apiCharacter";
 import { API_Chatroom_Data } from "./apiChatroom";
-import { API_Connector, CoordObject } from "./apiConnector";
+import { API_Connector } from "./apiConnector";
 import { EventEmitter } from "stream";
 import { ChatRoomMapViewObjectList, ChatRoomMapViewTileList } from "./bcdata/ChatRoomMap";
 
 export interface MapRegion {
-    TopLeft: CoordObject;
-    BottomRight: CoordObject;
+    TopLeft: ChatRoomMapPos;
+    BottomRight: ChatRoomMapPos;
 }
 
 function mapTileByName(name: string): ChatRoomMapTile {
@@ -33,7 +33,7 @@ function mapObjectByName(name: string): ChatRoomMapObject {
 }
 
 interface TileTrigger {
-    prevPos?: CoordObject;
+    prevPos?: ChatRoomMapPos;
     callback: TriggerCallback;
 }
 
@@ -42,14 +42,14 @@ interface RegionTrigger {
     callback: TriggerCallback;
 }
 
-type TriggerCallback = (char: API_Character, prevPos: CoordObject) => void;
+type TriggerCallback = (char: API_Character, prevPos: ChatRoomMapPos) => void;
 
-export function positionEquals(a: CoordObject, b: CoordObject): boolean {
+export function positionEquals(a: ChatRoomMapPos, b: ChatRoomMapPos): boolean {
     return a.X === b.X && a.Y === b.Y;
 }
 
 export function positionIsInRegion(
-    pos: CoordObject,
+    pos: ChatRoomMapPos,
     region: MapRegion,
 ): boolean {
     return (
@@ -61,7 +61,7 @@ export function positionIsInRegion(
 }
 
 export function makeDoorRegion(
-    pos: CoordObject,
+    pos: ChatRoomMapPos,
     above: boolean,
     below: boolean,
 ): MapRegion {
@@ -112,9 +112,9 @@ export class API_Map extends EventEmitter<MapEvents> {
     }
 
     public addTileTrigger(
-        where: CoordObject,
+        where: ChatRoomMapPos,
         callback: TriggerCallback,
-        prevPos?: CoordObject,
+        prevPos?: ChatRoomMapPos,
     ): void {
         const pos = where.X + where.Y * 40;
         const list = this.tileTriggers.get(pos) ?? [];
@@ -168,7 +168,7 @@ export class API_Map extends EventEmitter<MapEvents> {
         }
     }
 
-    public setTile(pos: CoordObject, tileName: string): void {
+    public setTile(pos: ChatRoomMapPos, tileName: string): void {
         if (!this.mapData) return;
 
         const tile = mapTileByName(tileName);
@@ -182,7 +182,7 @@ export class API_Map extends EventEmitter<MapEvents> {
         this.queueUpdate();
     }
 
-    public getObject(pos: CoordObject): string {
+    public getObject(pos: ChatRoomMapPos): string {
         if (!this.mapData) return "";
 
         const tileNum = pos.X + pos.Y * 40;
@@ -191,7 +191,7 @@ export class API_Map extends EventEmitter<MapEvents> {
         return obj?.Style;
     }
 
-    public setObject(pos: CoordObject, objectName: string): void {
+    public setObject(pos: ChatRoomMapPos, objectName: string): void {
         if (!this.mapData) return;
 
         const tile = mapObjectByName(objectName);
@@ -207,7 +207,7 @@ export class API_Map extends EventEmitter<MapEvents> {
 
     public onCharacterMove(
         character: API_Character,
-        prevPos: CoordObject,
+        prevPos: ChatRoomMapPos,
     ): void {
         // maybe? if necessary?
         //this.emit("CharacterMapMove", this.getCharacter(memberNumber));

--- a/src/bcdata/female3DCG.js
+++ b/src/bcdata/female3DCG.js
@@ -19177,6 +19177,31 @@ export var AssetFemale3DCG = [
 	},
 
 	{
+        Group: "BodyStyle",
+        Priority: 0,
+        AllowNone: false,
+        AllowColorize: false,
+        Asset: [
+            { Name: "Original", Visible: false },
+            {
+                Name: "EchoV1",
+                Visible: false,
+                StyleOverride: [
+                    "BodyUpper",
+                    "BodyLower",
+                    "ArmsRight",
+                    "ArmsLeft",
+                    "HandsRight",
+                    "HandsLeft",
+                    "Head",
+                    "Nipples",
+                    "Pussy",
+                ],
+            },
+        ],
+    },
+
+	{
 		Group: "BodyUpper",
 		Priority: 7,
 		AllowNone: false,

--- a/src/package.json
+++ b/src/package.json
@@ -10,7 +10,7 @@
         "compile": "rm -rf dist/* && tsc -p tsconfig.json"
     },
     "dependencies": {
-        "bc-stubs": "^116.0.0",
+        "bc-stubs": "117.0.0-Beta.1",
         "lz-string": "^1.5.0",
         "prettier": "^3.5.3",
         "socket.io-client": "^4.8.1"

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       bc-stubs:
-        specifier: ^116.0.0
-        version: 116.0.0
+        specifier: 117.0.0-Beta.1
+        version: 117.0.0-Beta.1
       lz-string:
         specifier: ^1.5.0
         version: 1.5.0
@@ -336,8 +336,8 @@ packages:
   '@types/node@20.17.57':
     resolution: {integrity: sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==}
 
-  bc-stubs@116.0.0:
-    resolution: {integrity: sha512-70iudcyWi2MacZR0W8LCQegDkgBIjiEoyBe2NuTM2Nvj6/p6MT1M80byOSc1CpBeIdSurkJw8RUFqrTL/mXU6Q==}
+  bc-stubs@117.0.0-Beta.1:
+    resolution: {integrity: sha512-sX0fHJY0h6H1a89QAD2oY8uAa2apTkbXaC4xU0LGmUpKcVdlSMjz3V+SO8iH+N9HbM2ev3mhiO5YC2GjTV/cbw==}
 
   debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
@@ -606,7 +606,7 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
-  bc-stubs@116.0.0:
+  bc-stubs@117.0.0-Beta.1:
     dependencies:
       socket.io-client: 4.6.1
     transitivePeerDependencies:


### PR DESCRIPTION
The map position messages have changed, so bots will need to update to their version of ropeybot to work with anyone running 117. This code won't work with 116 or earlier, so don't update bots until 117 is out.

Also remove the CoordObject type that's now in bc-stubs as ChatRoomMapPos: update code to use that instead of CoordObject.