### PR TITLE
Various fixes and changes

### DIFF
--- a/bin/games/casino/blackjack.ts
+++ b/bin/games/casino/blackjack.ts
@@ -25,7 +25,7 @@ const BLACKJACKCOMMANDS = `Blackjack commands:
 /bot hit - Take another card from the deck.
 /bot stand - Keep your current hand
 /bot double - Double your bet and take one more card. Only available on your first two cards.
-/bot split - Split your hand into two hands if you have two cards of the same value. 
+/bot split - Split your hand into two hands if you have two cards of the same value.
 /bot cancel - Cancel your bet. Only available before any cards are dealt.
 /bot chips - Show your current chip balance.
 /bot give <name or member number> <amount> - Give chips to another player.
@@ -137,7 +137,7 @@ export class BlackjackGame implements Game {
                 console.error("Failed to set bio.", e);
             });
 
-            this.conn.setScriptPermissions(true, false);
+            this.conn.Player.setScriptPermissions(true, false);
 
             const scriptItem = this.conn.Player.Appearance.AddItem(
                 AssetGet("ItemScript", "Script"),
@@ -190,7 +190,7 @@ export class BlackjackGame implements Game {
         pole = this.conn.Player.Appearance.AddItem(
             AssetGet("ItemDevices", "Pole"),
         );
-        console.log("Adding pole to appearance"); 
+        console.log("Adding pole to appearance");
         pole.SetColor(["#AC9A85"]);
 /**/
         console.log("Adding pole to inventory");

--- a/bin/games/casino/roulette.ts
+++ b/bin/games/casino/roulette.ts
@@ -184,7 +184,7 @@ export class RouletteGame implements Game {
                 console.error("Failed to set bio.", e);
             });
 
-            this.conn.setScriptPermissions(true, false);
+            this.conn.Player.setScriptPermissions(true, false);
 
             const scriptItem = this.conn.Player.Appearance.AddItem(
                 AssetGet("ItemScript", "Script"),

--- a/bin/hub/logic/administrationLogic.ts
+++ b/bin/hub/logic/administrationLogic.ts
@@ -744,10 +744,9 @@ export class AdministrationLogic extends LogicBase {
 
 			logger.alert(`${this.a_LogHeader(target.connection)} RoomGuard kicked ${target}: ${data.points}\n`, ...data.log);
 			target.connection.SendMessage("Emote", `*${target} has been automatically kicked by Room Guard™, as their actions have been detected as likely disruptive.`);
-			target.Kick().then(() => {
-				// Reset points to 0, resetting roomguard for specific user after kicking
-				data!.points = 0;
-			}, logger.fatal.bind(logger));
+			target.Kick();
+			// Reset points to 0, resetting roomguard for specific user after kicking
+			data.points = 0;
 
 			if (canBeBannedUntil != null && canBeBannedUntil >= Date.now()) {
 				this.a_start_kickvote(target.connection, true, target, target.connection.Player, "Room Guard™ detected repeated, likely disruptive or spammy actions.");

--- a/src/apiCharacter.ts
+++ b/src/apiCharacter.ts
@@ -169,9 +169,49 @@ export class API_Character {
     public unwhitelist(): void {
         this.manageWhitelist("remove", this.MemberNumber);
     }
+    // #region Online Shared Settings
+
     public get OnlineSharedSettings(): CharacterOnlineSharedSettings {
         return this.data.OnlineSharedSettings;
     }
+    get allowFullWardrobeAccess(): boolean {
+        return this.data.OnlineSharedSettings.AllowFullWardrobeAccess;
+    }
+    get blockBodyCosplay(): boolean {
+        return this.data.OnlineSharedSettings.BlockBodyCosplay;
+    }
+    get allowPlayerLeashing(): boolean {
+        return this.data.OnlineSharedSettings.AllowPlayerLeashing;
+    }
+    get allowRename(): boolean {
+        return this.data.OnlineSharedSettings.AllowRename;
+    }
+    get disablePickingLocksOnSelf(): boolean {
+        return this.data.OnlineSharedSettings.DisablePickingLocksOnSelf;
+    }
+    get gameVersion(): string {
+        return this.data.OnlineSharedSettings.GameVersion ?? "";
+    }
+    get itemsAffectExpressions(): boolean {
+        return this.data.OnlineSharedSettings.ItemsAffectExpressions;
+    }
+    // get WheelFortune(): string {
+    //     return this.data.OnlineSharedSettings.WheelFortune;
+    // }
+
+    public getScriptPermissions(): { hide: boolean; block: boolean } {
+        const ret = {
+            hide:
+                this.data.OnlineSharedSettings.ScriptPermissions.Hide
+                    .permission !== 0,
+            block:
+                this.data.OnlineSharedSettings.ScriptPermissions.Block
+                    .permission !== 0,
+        };
+        return ret;
+    }
+
+    // #endregion
     public get ItemPermission(): ItemPermissionLevel {
         return this.data.ItemPermission;
     }

--- a/src/apiCharacter.ts
+++ b/src/apiCharacter.ts
@@ -144,14 +144,39 @@ export class API_Character {
     public get WhiteList(): number[] {
         return this.data.WhiteList;
     }
+    protected manageWhitelist(arg: "add" | "remove", ...members: number[]) {
+        const list = new Set(this.connection.Player.WhiteList);
+        let update = false;
+        if (arg === "add") {
+            for (const member of members) {
+                if (member === this.MemberNumber) continue;
+                list.add(member);
+                update = true;
+            }
+        } else if (arg === "remove") {
+            for (const member of members) {
+                list.delete(member);
+                update = true;
+            }
+        }
+        if (update) {
+            this.connection.accountUpdate({ WhiteList: [...list.values()] });
+        }
+    }
+    public whitelist(): void {
+        this.manageWhitelist("add", this.MemberNumber);
+    }
+    public unwhitelist(): void {
+        this.manageWhitelist("remove", this.MemberNumber);
+    }
     public get OnlineSharedSettings(): CharacterOnlineSharedSettings {
         return this.data.OnlineSharedSettings;
     }
     public get ItemPermission(): ItemPermissionLevel {
         return this.data.ItemPermission;
     }
-    public get ChatRoomPosition(): number {
-        return 0; /* TODO */
+    public get ChatRoomPosition(): number | undefined {
+        return this.chatRoom?.characters.indexOf(this);
     }
     public get chatRoom(): API_Chatroom | undefined {
         return this.connection._chatRoom;

--- a/src/apiCharacter.ts
+++ b/src/apiCharacter.ts
@@ -120,7 +120,6 @@ export class API_Character {
     constructor(
         protected readonly data: API_Character_Data,
         public readonly connection: API_Connector,
-        private _chatRoom?: API_Chatroom,
     ) {
         this._appearance = new AppearanceType(this, data);
     }
@@ -154,14 +153,9 @@ export class API_Character {
     public get ChatRoomPosition(): number {
         return 0; /* TODO */
     }
-
     public get chatRoom(): API_Chatroom | undefined {
-        return this._chatRoom;
+        return this.connection._chatRoom;
     }
-    public set chatRoom(room: API_Chatroom) {
-        this._chatRoom = room;
-    }
-
     public get X(): number {
         return this.data.MapData?.Pos?.X ?? 0;
     }
@@ -329,7 +323,7 @@ export class API_Character {
     }
 
     public MoveToPos(pos: number): void {
-        this._chatRoom?.moveCharacterToPos(this.data.MemberNumber, pos);
+        this.chatRoom?.moveCharacterToPos(this.data.MemberNumber, pos);
     }
 
     public SetExpression(

--- a/src/apiCharacter.ts
+++ b/src/apiCharacter.ts
@@ -248,7 +248,7 @@ export class API_Character {
         return upperBody?.Name === "Penis" ? "male" : "female";
     }
 
-    public async Kick(): Promise<void> {
+    public Kick(): void {
         this.connection.chatRoomAdmin({
             Action: "Kick",
             MemberNumber: this.MemberNumber,
@@ -256,9 +256,17 @@ export class API_Character {
         });
     }
 
-    public Ban(): void {}
+    public Ban(): void {
+        this.chatRoom?.banCharacter(this);
+    }
 
-    public Demote(): void {}
+    public Promote(): void {
+        this.chatRoom?.promoteAdmin(this);
+    }
+
+    public Demote(): void {
+        this.chatRoom?.demoteAdmin(this);
+    }
 
     public IsBot(): boolean {
         return this.data.MemberNumber === this.connection.Player.MemberNumber;

--- a/src/apiChatroom.ts
+++ b/src/apiChatroom.ts
@@ -271,6 +271,7 @@ export class API_Chatroom extends EventEmitter<ChatRoomEvents> {
                 });
             }
         }
+        this.conn.emit("CharacterSync", char);
     }
 
     public characterItemUpdate(itemUpdate: ServerCharacterItemUpdate) {

--- a/src/apiChatroom.ts
+++ b/src/apiChatroom.ts
@@ -18,7 +18,7 @@ import {
     API_Character_Data,
     transformToCharacterData,
 } from "./apiCharacter.ts";
-import { API_Connector } from "./apiConnector.ts";
+import { API_Connector, API_Error } from "./apiConnector.ts";
 import { API_Map } from "./apiMap.ts";
 import { API_AppearanceItem } from "./item.ts";
 import { API_PlayerCharacter } from "./playerCharacter.ts";
@@ -410,7 +410,13 @@ export class API_Chatroom extends EventEmitter<ChatRoomEvents> {
         return this.characterFromCache(char);
     }
 
-    public moveCharacterToPos(memberNo: number, pos: number): Promise<void> {
+    public async moveCharacterToPos(
+        memberNo: number,
+        pos: number,
+    ): Promise<void> {
+        if (!this.conn.Player.IsRoomAdmin()) {
+            throw new API_Error("NotAdmin", "You are not an admin of the room");
+        }
         const prom = new Promise<void>((resolve) => {
             this.reorderWatcher.once("reorder", resolve);
             setTimeout(resolve, 1000);

--- a/src/apiChatroom.ts
+++ b/src/apiChatroom.ts
@@ -93,9 +93,41 @@ export class API_Chatroom extends EventEmitter<ChatRoomEvents> {
     }
     public set Admin(value: number[]) {
         this.data.Admin = value;
+        this.saveChanges();
+    }
+    public promoteAdmin(char: API_Character | number) {
+        const member = typeof char === "number" ? char : char.MemberNumber;
+        this.conn.chatRoomAdmin({
+            Action: "Promote",
+            MemberNumber: member,
+            Publish: true,
+        });
+    }
+    public demoteAdmin(char: API_Character | number) {
+        const member = typeof char === "number" ? char : char.MemberNumber;
+        this.conn.chatRoomAdmin({
+            Action: "Demote",
+            MemberNumber: member,
+            Publish: true,
+        });
     }
     public get Ban(): number[] {
         return this.data.Ban;
+    }
+    public banCharacter(char: API_Character | number) {
+        const member = typeof char === "number" ? char : char.MemberNumber;
+        this.conn.chatRoomAdmin({
+            Action: "Ban",
+            MemberNumber: member,
+            Publish: true,
+        });
+    }
+    public unbanCharacter(member: number) {
+        this.conn.chatRoomAdmin({
+            Action: "Unban",
+            MemberNumber: member,
+            Publish: true,
+        });
     }
     public get Private(): boolean {
         return this.data.Private;

--- a/src/apiChatroom.ts
+++ b/src/apiChatroom.ts
@@ -178,7 +178,7 @@ export class API_Chatroom extends EventEmitter<ChatRoomEvents> {
     private characterFromCache(data: API_Character_Data) {
         let char = this.characterCache.get(data.MemberNumber);
         if (!char) {
-            char = new API_Character(data, this.conn, this);
+            char = new API_Character(data, this.conn);
             this.characterCache.set(char.MemberNumber, char);
 
             if (this.characterCache.size > 20) this.pruneCharacterCache();

--- a/src/apiConnector.ts
+++ b/src/apiConnector.ts
@@ -329,7 +329,7 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
     };
 
     private onLoginResponse = (resp: ServerLoginResponse) => {
-        console.log("Got login response", resp);
+        // console.log("Got login response", resp);
         if (resp === "InvalidNamePassword") {
             throw new API_Error(
                 "InvalidNamePassword",
@@ -340,6 +340,10 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
         this._player = new API_PlayerCharacter(charData, this, undefined);
         this.loggedIn.resolve();
     };
+
+    public async login() {
+        return this.loggedIn.prom;
+    }
 
     private onChatRoomCreateResponse = (resp: string) => {
         console.log("Got chat room create response", resp);

--- a/src/apiConnector.ts
+++ b/src/apiConnector.ts
@@ -76,7 +76,7 @@ class PromiseResolve<T> {
     }
 }
 
-class API_Error extends Error {
+export class API_Error extends Error {
     constructor(name: string, message: string, options?: ErrorOptions) {
         super(message, options);
         this.name = name;

--- a/src/apiConnector.ts
+++ b/src/apiConnector.ts
@@ -95,6 +95,7 @@ interface ConnectorEvents {
     RoomJoin: [];
     RoomCreate: [];
     CharacterEntered: [character: API_Character];
+    CharacterSync: [character: API_Character];
     CharacterLeft: [
         sourceMemberNumber: number,
         character: API_Character,

--- a/src/apiConnector.ts
+++ b/src/apiConnector.ts
@@ -780,29 +780,6 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
         });
     }
 
-    public setScriptPermissions(hide: boolean, block: boolean): void {
-        this.accountUpdate({
-            OnlineSharedSettings: {
-                GameVersion: GAMEVERSION,
-                ScriptPermissions: {
-                    Hide: {
-                        permission: hide ? 1 : 0,
-                    },
-                    Block: {
-                        permission: block ? 1 : 0,
-                    },
-                },
-                AllowFullWardrobeAccess: false,
-                BlockBodyCosplay: true,
-                AllowPlayerLeashing: false,
-                AllowRename: false,
-                DisablePickingLocksOnSelf: true,
-                ItemsAffectExpressions: false,
-                WheelFortune: "",
-            },
-        });
-    }
-
     public updateCharacterItem(update: ServerCharacterItemUpdate): void {
         /*if (update.Target === this.Player.MemberNumber) {
             const payload = {

--- a/src/apiConnector.ts
+++ b/src/apiConnector.ts
@@ -650,6 +650,8 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
             return result === "JoinedRoom";
         }
 
+        await this.loggedIn.prom;
+
         this.roomJoinPromise = new PromiseResolve();
 
         try {
@@ -681,6 +683,8 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
             const result = await this.roomCreatePromise.prom;
             return result === "ChatRoomCreated";
         }
+
+        await this.loggedIn.prom;
 
         console.log("creating room");
         this.roomCreatePromise = new PromiseResolve();

--- a/src/apiConnector.ts
+++ b/src/apiConnector.ts
@@ -856,13 +856,8 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
     }
 
     public accountUpdate(update: Partial<API_Character_Data>): void {
-        const actualUpdate = { ...update };
-        if (actualUpdate.Appearance === undefined) {
-            actualUpdate.Appearance =
-                this.Player.Appearance.getAppearanceData();
-        }
         //console.log("Sending account update", actualUpdate);
-        this.wrappedSock.emit("AccountUpdate", actualUpdate);
+        this.wrappedSock.emit("AccountUpdate", update);
     }
 
     public moveOnMap(x: number, y: number): void {

--- a/src/playerCharacter.ts
+++ b/src/playerCharacter.ts
@@ -1,5 +1,4 @@
 import { API_Character, API_Character_Data } from "./apiCharacter.ts";
-import { API_Chatroom } from "./apiChatroom.ts";
 import { API_Connector } from "./apiConnector.ts";
 import { BC_AppearanceItem } from "./item.ts";
 
@@ -7,9 +6,8 @@ export class API_PlayerCharacter extends API_Character {
     constructor(
         protected data: API_Character_Data,
         connection: API_Connector,
-        chatRoom?: API_Chatroom,
     ) {
-        super(data, connection, chatRoom);
+        super(data, connection);
     }
 
     public sendItemUpdate(data: BC_AppearanceItem): void {

--- a/src/playerCharacter.ts
+++ b/src/playerCharacter.ts
@@ -63,4 +63,11 @@ export class API_PlayerCharacter extends API_Character {
             });
         }
     }
+
+    public addWhitelist(...members: number[]): void {
+        this.manageWhitelist("add", ...members);
+    }
+    public removeWhitelist(...members: number[]): void {
+        this.manageWhitelist("remove", ...members);
+    }
 }

--- a/src/playerCharacter.ts
+++ b/src/playerCharacter.ts
@@ -10,6 +10,55 @@ export class API_PlayerCharacter extends API_Character {
         super(data, connection);
     }
 
+    // #region Online Shared Settings
+
+    private updateOnlineSharedSettings(): void {
+        this.connection.accountUpdate({
+            OnlineSharedSettings: this.data.OnlineSharedSettings,
+        });
+    }
+
+    set allowFullWardrobeAccess(value: boolean) {
+        this.data.OnlineSharedSettings.AllowFullWardrobeAccess = value;
+        this.updateOnlineSharedSettings();
+    }
+
+    set blockBodyCosplay(value: boolean) {
+        this.data.OnlineSharedSettings.BlockBodyCosplay = value;
+        this.updateOnlineSharedSettings();
+    }
+
+    set allowPlayerLeashing(value: boolean) {
+        this.data.OnlineSharedSettings.AllowPlayerLeashing = value;
+        this.updateOnlineSharedSettings();
+    }
+
+    set allowRename(value: boolean) {
+        this.data.OnlineSharedSettings.AllowRename = value;
+        this.updateOnlineSharedSettings();
+    }
+
+    set disablePickingLocksOnSelf(value: boolean) {
+        this.data.OnlineSharedSettings.DisablePickingLocksOnSelf = value;
+        this.updateOnlineSharedSettings();
+    }
+
+    set itemsAffectExpressions(value: boolean) {
+        this.data.OnlineSharedSettings.ItemsAffectExpressions = value;
+        this.updateOnlineSharedSettings();
+    }
+
+    public setScriptPermissions(hide: boolean, block: boolean): void {
+        this.data.OnlineSharedSettings.ScriptPermissions.Hide.permission = hide
+            ? 1
+            : 0;
+        this.data.OnlineSharedSettings.ScriptPermissions.Block.permission =
+            block ? 1 : 0;
+        this.updateOnlineSharedSettings();
+    }
+
+    // #endregion
+
     public sendItemUpdate(data: BC_AppearanceItem): void {
         super.sendItemUpdate(data);
         this.connection.accountUpdate({ Appearance: this.data.Appearance });

--- a/src/playerCharacter.ts
+++ b/src/playerCharacter.ts
@@ -1,6 +1,7 @@
 import { API_Character, API_Character_Data } from "./apiCharacter.ts";
 import { API_Chatroom } from "./apiChatroom.ts";
 import { API_Connector } from "./apiConnector.ts";
+import { BC_AppearanceItem } from "./item.ts";
 
 export class API_PlayerCharacter extends API_Character {
     constructor(
@@ -9,6 +10,16 @@ export class API_PlayerCharacter extends API_Character {
         chatRoom?: API_Chatroom,
     ) {
         super(data, connection, chatRoom);
+    }
+
+    public sendItemUpdate(data: BC_AppearanceItem): void {
+        super.sendItemUpdate(data);
+        this.connection.accountUpdate({ Appearance: this.data.Appearance });
+    }
+
+    public sendAppearanceUpdate(): void {
+        super.sendAppearanceUpdate();
+        this.connection.accountUpdate({ Appearance: this.data.Appearance });
     }
 
     get friendList(): number[] {


### PR DESCRIPTION
This goes on top of #17, so the first few commits are from that other one.

The rest is just things I missed or was bothered with, like:
- raising exceptions for not being able to login or admin-move the player.
- better handling of whether the login happened or not by exposing `API_Connector.isLogged` and checking that inside *some* of the methods (room creation and joining, but they should really all be doing that).
- simplify the management of the chatroom; there's really only one chatroom ever: the one the player is joined into. Any other character we see *is* in that room. Hence it doesn't make sense to have a bunch of accessors and mutators all over the place, just make it all use the same chatroom object internally.
- Stop sending the complete player appearance any time something wants to do an `AccountUpdate` — instead, hide that inside `API_PlayerCharacter`, as it knows when to update the chatroom with changes already, so just make it update the account as well.
- Whitelist, Banning, Admin promotion support added.