### PR TITLE
fix(api-connector): fix CharacterLeft event always getting skipped

### DIFF
--- a/src/apiConnector.ts
+++ b/src/apiConnector.ts
@@ -397,10 +397,10 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
             `chat room member left with reason ${this.leaveReasons.get(resp.SourceMemberNumber)}`,
             resp,
         );
-        this._chatRoom!.memberLeft(resp.SourceMemberNumber);
         const leftMember = this._chatRoom!.getCharacter(
             resp.SourceMemberNumber,
         );
+        this._chatRoom!.memberLeft(resp.SourceMemberNumber);
         if (!leftMember) return;
 
         const isIntentional =


### PR DESCRIPTION
This may have been a logic error, the `CharacterLeft` event will never get fired because of `leftMember` always being `undefined`.
This guarantee is because of the following code flow:
1. `this._chatRoom!.memberLeft` will remove the member from the `API_ChatRoom.data.Character` list
2. `this._chatRoom!.getCharacter` will try to find it from that same `API_ChatRoom.data.Character` list which will always have it removed from `1.`

As such, there will never be a case where the `CharacterLeft` code path will run if the character will always not be found