### PR TITLE
fix(api-connector): fix invalid room on recreation

### DIFF
--- a/src/apiConnector.ts
+++ b/src/apiConnector.ts
@@ -367,6 +367,14 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
         delete roomData.Character;
         // @ts-expect-error not part of RoomDefinition
         delete roomData.SourceMemberNumber;
+        /** fixes invalid room data on reconnection @see {@link API_Connector.onChatRoomSyncRoomProperties} */
+        // remove these if they're there. The server will have converted to new
+        // Access / Visibility fields and won't accept a ChatRoomCreate with both
+        // Private/Locked and Access/Visibility
+        // @ts-expect-error not part of RoomDefinition
+        delete roomData.Private;
+        // @ts-expect-error not part of RoomDefinition
+        delete roomData.Locked;
         this.roomJoined = roomData;
         this.roomSynced.resolve();
     };
@@ -434,14 +442,14 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
         // a void, we recreate the room with the same settings
         const roomData = structuredClone(resp);
         // @ts-expect-error not part of RoomDefinition
-        delete resp.SourceMemberNumber;
+        delete roomData.SourceMemberNumber;
         // remove these if they're there. The server will have converted to new
         // Access / Visibility fields and won't accept a ChatRoomCreate with both
         // Private/Locked and Access/Visibility
         // @ts-expect-error not part of RoomDefinition
-        delete resp.Private;
+        delete roomData.Private;
         // @ts-expect-error not part of RoomDefinition
-        delete resp.Locked;
+        delete roomData.Locked;
 
         this.roomJoined = roomData;
     };


### PR DESCRIPTION
noticed issues when recreating a room after a re-connection where it complains that the room data is invalid, this is because of `Locked`/`Private` existing alongside `Access`/`Visibility`, this occurs because of `this.roomJoined` being assigned a room definition with those incompatible fields on `onChatRoomSyncRoomProperties` and `onChatRoomSync`.

seems like there was an attempt to do so in `onChatRoomSyncRoomProperties` but is applied to the wrong object, and a missing attempt to do so in `onChatRoomSync`, so this PR adds that missing check.

not sure if it might be better to do this deletion in `joinOrCreateRoom` or not for sanity sake instead of having to delete it everywhere `this.roomJoined` is assigned.