### PR TITLE
fix(api-connector): ensure no hanging on reconnection

### DIFF
--- a/src/apiConnector.ts
+++ b/src/apiConnector.ts
@@ -320,6 +320,17 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
 
     private onSocketDisconnect = () => {
         console.log("Socket disconnected");
+
+        // clean up existing promises and resolve them if any to prevent a stuck await (i.e. disconnect when waiting for roomJoinPromise)
+        if (this.roomJoinPromise) {
+            this.roomJoinPromise.resolve("SocketDisconnected");
+            this.roomJoinPromise = undefined;
+        }
+        if (this.roomCreatePromise) {
+            this.roomCreatePromise.resolve("SocketDisconnected");
+            this.roomCreatePromise = undefined;
+        }
+
         this.loggedIn = new PromiseResolve<void>();
         this.roomSynced = new PromiseResolve<void>();
     };
@@ -648,18 +659,20 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
 
         this.roomJoinPromise = new PromiseResolve();
 
+        let result;
         try {
             this.wrappedSock.emit("ChatRoomJoin", {
                 Name: name,
             });
 
-            const joinResult = await this.roomJoinPromise.prom;
-            if (joinResult !== "JoinedRoom") {
-                console.log("Failed to join room", joinResult);
-                return false;
-            }
+            result = await this.roomJoinPromise.prom;
         } finally {
             this.roomJoinPromise = undefined;
+        }
+        
+        if (result !== "JoinedRoom") {
+            console.error("Failed to join room", result);
+            return false;
         }
 
         console.log("Room joined");
@@ -696,7 +709,8 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
         }
 
         if (result !== "ChatRoomCreated") {
-            throw new API_Error(result, "Failed to create room");
+            console.error("Failed to create room", result);
+            return false;
         }
 
         console.log("Room created");
@@ -710,14 +724,23 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
 
     public async joinOrCreateRoom(roomDef: RoomDefinition): Promise<void> {
         await this.loggedIn.prom;
+        // store a reference to the current instance of PromiseResolve that was
+        // awaited, acting like a session id
+        const logInSession = this.loggedIn;
 
         // after a void, we can race between creating the room and other players
         // reappearing and creating it, so we need to try both until one works
-        while (true) {
+        //
+        // only continue retrying if this joinOrCreateRoom call is still the
+        // active login session and isn't one that has disconnected already
+        while (logInSession === this.loggedIn) {
             console.log("Trying to join room...", roomDef);
             const joinResult = await this.ChatRoomJoin(roomDef.Name);
             if (joinResult) return;
 
+            // relinquish responsibility to the actual active login session if this
+            // joinOrCreateRoom call is from an old disconnected session
+            if (logInSession !== this.loggedIn) return;
             console.log("Failed to join room, trying to create...", roomDef);
             const createResult = await this.ChatRoomCreate(roomDef);
             if (createResult) return;

--- a/src/apiConnector.ts
+++ b/src/apiConnector.ts
@@ -669,7 +669,7 @@ export class API_Connector extends EventEmitter<ConnectorEvents> {
         } finally {
             this.roomJoinPromise = undefined;
         }
-        
+
         if (result !== "JoinedRoom") {
             console.error("Failed to join room", result);
             return false;


### PR DESCRIPTION
### Description
after encountering the issue described in #3, went to investigate and test further, simulating disconnects and reconnection scenarios, I have discovered that this issue arises in the event of a reconnection to join or create a room, and then suddenly disconnects again before the reconnection could complete joining or creating the room.

as such, upon the next reconnect attempt, the old previous halfway-attempted room creation or joining has still not resolved as it can only be resolved if the client has received the server event, which was impossible due to the disconnection. with that, this next reconnect attempt will be stuck in the following places, waiting for a promise that never resolves, effectively hanging the whole bot reconnection attempt without any explicit logs or indication, this forever await would then exist in both the previous reconnection attempt and the subsequent next attempt as follows:

previous reconnection attempt hanging part
- `roomJoinPromise`: https://github.com/tenjou-no-kitsune/bc-bot-sdk/blob/398c8a65311d958f6b52e84c1cf9a44ff3721c01/src/apiConnector.ts#L668
- `roomCreatePromise`: https://github.com/tenjou-no-kitsune/bc-bot-sdk/blob/398c8a65311d958f6b52e84c1cf9a44ff3721c01/src/apiConnector.ts#L706

subsequent next reconnection attempt hanging part:
- `roomJoinPromise`: https://github.com/tenjou-no-kitsune/bc-bot-sdk/blob/398c8a65311d958f6b52e84c1cf9a44ff3721c01/src/apiConnector.ts#L654
- `roomCreatePromise`: https://github.com/tenjou-no-kitsune/bc-bot-sdk/blob/398c8a65311d958f6b52e84c1cf9a44ff3721c01/src/apiConnector.ts#L689

my proposed solution to the reconnection issues is to clean up and resolve the promises on a disconnect, which would notify the attempt to create or join room that there has been a disconnect and it shouldn't be waiting for promises that never resolves, by resolving it with a result of `"SocketDisconnected"` and removing the promises, setting them to undefined so a fresh one can be made again.

with that, this would cause an error when room creation fails with `"SocketDisconnected"` as a result, hence why i propose changing it to just a log instead of throwing an error, since it isn't fatal, if there can be a later reconnection attempt.

along with these issues being fixed, also comes the problem of how we may have multiple invocations of `joinOrCreateRoom` coming from the different reconnection attempts, to mitigate that, I have decided to keep a reference to the `loggedIn` PromiseResolve after a successful await in the `joinOrCreateRoom`, so that in retry attempts, the function itself can check and know whether it is considered obsolete and there has been a new `joinOrCreateRoom` execution context coming from a reconnection as the `loggedIn` PromiseResolve instance would have been reassigned and become different.

### Changelog
> fixes #3 issue whereby reconnection doesnt trigger any further attempts to recreate or rejoin rooms
- `onSocketDisconnect`: adds cleanup and resolution to pending promises on disconnection to prevent perpetual awaits on promises that will never get resolved due to disconnection
- `ChatRoomJoin`: move code flow of checking result out of the try finally block, for consistency with ChatRoomCreate
- `ChatRoomCreate`: change error being thrown to just a log instead of a fatal error as a disconnection shouldn't crash the bot
- `joinOrCreateRoom`: ensure the retry attempts is coming from the latest login session instead of an outdated disconnected login invocation

